### PR TITLE
docs: repoint tutorial video embeds to published attachment URLs

### DIFF
--- a/docs/lerobot-luckyengine-tutorial/README.md
+++ b/docs/lerobot-luckyengine-tutorial/README.md
@@ -19,21 +19,21 @@ LeRobot dataset format.
 
 **Manual leader-arm teleop** — one human, one demo at a time
 
-<video src="https://github.com/user-attachments/assets/17a122b4-b880-4422-af7f-497fd37d2cb9" controls muted width="100%"></video>
+<video src="https://github.com/user-attachments/assets/0274d5c0-7600-4299-b734-ba66ad0446b1" controls muted width="100%"></video>
 
-<sub>▶️ [hero_teleop.mp4](https://github.com/user-attachments/assets/17a122b4-b880-4422-af7f-497fd37d2cb9)</sub>
+<sub>▶️ [hero_teleop.mp4](https://github.com/user-attachments/assets/0274d5c0-7600-4299-b734-ba66ad0446b1)</sub>
 
 **Scripted in LuckyEngine** — hands-free, repeatable, same dataset format
 
-<video src="https://github.com/user-attachments/assets/bdea560b-1175-45c9-b4a0-71a616ea81c8" controls muted width="100%"></video>
+<video src="https://github.com/user-attachments/assets/dbb5e470-de5a-4b11-b4e5-a0c091bf7315" controls muted width="100%"></video>
 
-<sub>▶️ [hero_sim.mp4](https://github.com/user-attachments/assets/bdea560b-1175-45c9-b4a0-71a616ea81c8)</sub>
+<sub>▶️ [hero_sim.mp4](https://github.com/user-attachments/assets/dbb5e470-de5a-4b11-b4e5-a0c091bf7315)</sub>
 
 **The payoff** — the same checkpoint, autonomous on the real SO-100 (two-camera DICE-IMLE @ 30 Hz)
 
-<video src="https://github.com/user-attachments/assets/c83c4fb0-23d2-4ed1-a09b-91e1e6d3adad" controls muted width="100%"></video>
+<video src="https://github.com/user-attachments/assets/26c5ff9e-6efd-43bf-92a3-c6d603e6cbfc" controls muted width="100%"></video>
 
-<sub>▶️ [hero_sim2real.mp4](https://github.com/user-attachments/assets/c83c4fb0-23d2-4ed1-a09b-91e1e6d3adad)</sub>
+<sub>▶️ [hero_sim2real.mp4](https://github.com/user-attachments/assets/26c5ff9e-6efd-43bf-92a3-c6d603e6cbfc)</sub>
 
 ---
 
@@ -44,15 +44,15 @@ writes a LeRobot 3.0 dataset to disk in parallel.
 
 **End-to-end walkthrough of recording demonstrations in LE**
 
-<video src="https://github.com/user-attachments/assets/99eb681d-80f6-44be-814f-c86d0ae9f842" controls muted width="100%"></video>
+<video src="https://github.com/user-attachments/assets/010ce79e-2a9c-471a-b7bb-7c4bacea058c" controls muted width="100%"></video>
 
-<sub>▶️ [recording_walkthrough.mp4](https://github.com/user-attachments/assets/99eb681d-80f6-44be-814f-c86d0ae9f842)</sub>
+<sub>▶️ [recording_walkthrough.mp4](https://github.com/user-attachments/assets/010ce79e-2a9c-471a-b7bb-7c4bacea058c)</sub>
 
 **SO-100 pick-and-place recorded inside LuckyEngine** — the dataset behind the case study
 
-<video src="https://github.com/user-attachments/assets/4f3ba857-fc91-4cce-88cc-907b7a841d56" controls muted width="100%"></video>
+<video src="https://github.com/user-attachments/assets/8ba270a6-b983-496a-bfaf-87f43e686443" controls muted width="100%"></video>
 
-<sub>▶️ [so100_sim.mp4](https://github.com/user-attachments/assets/4f3ba857-fc91-4cce-88cc-907b7a841d56)</sub>
+<sub>▶️ [so100_sim.mp4](https://github.com/user-attachments/assets/8ba270a6-b983-496a-bfaf-87f43e686443)</sub>
 
 ---
 
@@ -60,9 +60,9 @@ writes a LeRobot 3.0 dataset to disk in parallel.
 
 **Trained policy running in LE during in-domain eval** — finalist checkpoint at 96×96 / 30 fps
 
-<video src="https://github.com/user-attachments/assets/b45317d8-5bd5-40ce-bd2d-c5550e9de8af" controls muted width="100%"></video>
+<video src="https://github.com/user-attachments/assets/e5cdea1b-9028-4357-b2b8-0f327b2ee795" controls muted width="100%"></video>
 
-<sub>▶️ [le_finalist_trials.mp4](https://github.com/user-attachments/assets/b45317d8-5bd5-40ce-bd2d-c5550e9de8af)</sub>
+<sub>▶️ [le_finalist_trials.mp4](https://github.com/user-attachments/assets/e5cdea1b-9028-4357-b2b8-0f327b2ee795)</sub>
 
 ---
 
@@ -70,9 +70,9 @@ writes a LeRobot 3.0 dataset to disk in parallel.
 
 **Vanilla IMLE checkpoint `044800`, zero-shot in Genesis** — 96×96 @ 30 fps
 
-<video src="https://github.com/user-attachments/assets/bd0307ac-e452-449f-b53e-cd7144f9339a" controls muted width="100%"></video>
+<video src="https://github.com/user-attachments/assets/ee06523f-9028-45dd-b07e-6e37f98cbf65" controls muted width="100%"></video>
 
-<sub>▶️ [genesis_sim2sim.mp4](https://github.com/user-attachments/assets/bd0307ac-e452-449f-b53e-cd7144f9339a)</sub>
+<sub>▶️ [genesis_sim2sim.mp4](https://github.com/user-attachments/assets/ee06523f-9028-45dd-b07e-6e37f98cbf65)</sub>
 
 ---
 
@@ -80,9 +80,9 @@ writes a LeRobot 3.0 dataset to disk in parallel.
 
 **Real SO-100 running the same checkpoint trained only on simulator demos**
 
-<video src="https://github.com/user-attachments/assets/8cb3b6d9-d4b6-4430-993c-7c690854dbcc" controls muted width="100%"></video>
+<video src="https://github.com/user-attachments/assets/7a348355-34d0-472e-9b7a-52bb1c209f6c" controls muted width="100%"></video>
 
-<sub>▶️ [sim2real_real_robot.mp4](https://github.com/user-attachments/assets/8cb3b6d9-d4b6-4430-993c-7c690854dbcc)</sub>
+<sub>▶️ [sim2real_real_robot.mp4](https://github.com/user-attachments/assets/7a348355-34d0-472e-9b7a-52bb1c209f6c)</sub>
 
 ---
 
@@ -90,9 +90,9 @@ writes a LeRobot 3.0 dataset to disk in parallel.
 
 **Building a scene in LuckyEngine and getting it ready for recording**
 
-<video src="https://github.com/user-attachments/assets/9dad2763-90e3-43be-bcb9-30a781a8407f" controls muted width="100%"></video>
+<video src="https://github.com/user-attachments/assets/75a46b2d-2721-419b-879e-2e7d99c07ca7" controls muted width="100%"></video>
 
-<sub>▶️ [scene_creation.mp4](https://github.com/user-attachments/assets/9dad2763-90e3-43be-bcb9-30a781a8407f)</sub>
+<sub>▶️ [scene_creation.mp4](https://github.com/user-attachments/assets/75a46b2d-2721-419b-879e-2e7d99c07ca7)</sub>
 
 ---
 


### PR DESCRIPTION
Swap the 9 README video embeds from the draft-issue URLs (visible only to the uploader) to the published attachment URLs so they render for everyone.